### PR TITLE
fix: checkout fetch-depth: 0 추가 (커밋 SHA 지원)

### DIFF
--- a/.github/workflows/terraform-v3-k8s.yml
+++ b/.github/workflows/terraform-v3-k8s.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || '' }}
+          fetch-depth: 0
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -153,6 +154,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          fetch-depth: 0
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -193,6 +195,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          fetch-depth: 0
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
## Summary
- 3개 checkout 스텝에 `fetch-depth: 0` 추가
- shallow clone(기본 depth=1)에서는 커밋 SHA로 checkout 불가 → full clone으로 수정
- workflow_dispatch에서 `ref` 입력 시 정상 동작

## 변경 파일
- `.github/workflows/terraform-v3-k8s.yml` — plan/apply/destroy 3개 job의 checkout 스텝