### PR TITLE
fix: short SHA checkout 지원

### DIFF
--- a/.github/workflows/terraform-v3-k8s.yml
+++ b/.github/workflows/terraform-v3-k8s.yml
@@ -45,8 +45,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || '' }}
           fetch-depth: 0
+
+      - name: Checkout ref
+        if: inputs.ref != ''
+        run: git checkout ${{ inputs.ref }}
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -153,8 +156,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
           fetch-depth: 0
+
+      - name: Checkout ref
+        run: git checkout ${{ inputs.ref }}
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -194,8 +199,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
           fetch-depth: 0
+
+      - name: Checkout ref
+        run: git checkout ${{ inputs.ref }}
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
## Summary
- `actions/checkout@v4`는 40자 full SHA만 커밋으로 인식, 7자 short SHA는 브랜치/태그로 취급하여 실패
- main을 먼저 checkout(full history) 후 `git checkout <sha>`로 전환하는 방식으로 변경
- short SHA, full SHA 모두 정상 동작

## 변경 파일
- `.github/workflows/terraform-v3-k8s.yml` — plan/apply/destroy 3개 job의 checkout 로직