### PR TITLE
fix: NAT EIP 제거 (dev 동적 IP 사용)

### DIFF
--- a/IaC/3-v3/aws/environments/k8s-dev/outputs.tf
+++ b/IaC/3-v3/aws/environments/k8s-dev/outputs.tf
@@ -16,11 +16,6 @@ output "workers" {
 
 # --- Networking ---
 
-output "nat_eip_public_ip" {
-  description = "NAT EIP 퍼블릭 IP (모니터링 SG 허용 등)"
-  value       = module.nat_instance.eip_public_ip
-}
-
 output "k8s_subnet_ids" {
   description = "K8S 서브넷 ID 맵"
   value       = module.k8s_networking.private_subnet_ids

--- a/IaC/3-v3/aws/modules/nat-instance/main.tf
+++ b/IaC/3-v3/aws/modules/nat-instance/main.tf
@@ -1,6 +1,6 @@
 # ============================================================
 # V3 K8S IaC — NAT Instance (ASG 래핑, dev: 1대 / prod: AZ별)
-# ASG Min=Max=1 + user_data에서 EIP 연결 + RT route 갱신
+# ASG Min=Max=1 + user_data에서 RT route 갱신
 # Branch: feat/v3-k8s-iac
 # ============================================================
 
@@ -54,17 +54,7 @@ resource "aws_security_group" "nat" {
   })
 }
 
-# --- EIP (ASG 교체 시 user_data에서 재연결) ---
-
-resource "aws_eip" "nat" {
-  domain = "vpc"
-
-  tags = merge(var.common_tags, {
-    Name = "${var.project_name}-nat-eip"
-  })
-}
-
-# --- IAM Role (NAT 전용: SSM + EIP/Route 권한) ---
+# --- IAM Role (NAT 전용: SSM + Route 권한) ---
 
 resource "aws_iam_role" "nat" {
   name = "${var.project_name}-nat-role"
@@ -103,7 +93,6 @@ resource "aws_iam_role_policy" "nat_self_heal" {
       {
         Effect = "Allow"
         Action = [
-          "ec2:AssociateAddress",
           "ec2:ModifyInstanceAttribute",
           "ec2:ReplaceRoute",
           "ec2:CreateRoute"
@@ -147,7 +136,6 @@ resource "aws_launch_template" "nat" {
 
   user_data = base64encode(templatefile("${path.module}/user_data.sh.tpl", {
     vpc_cidr        = var.vpc_cidr
-    eip_alloc_id    = aws_eip.nat.id
     route_table_ids = join(",", var.route_table_ids)
     region          = var.region
   }))

--- a/IaC/3-v3/aws/modules/nat-instance/outputs.tf
+++ b/IaC/3-v3/aws/modules/nat-instance/outputs.tf
@@ -2,11 +2,6 @@
 # V3 K8S IaC — NAT Instance Outputs
 # ============================================================
 
-output "eip_public_ip" {
-  description = "NAT EIP 퍼블릭 IP (모니터링 SG 허용 등에 사용)"
-  value       = aws_eip.nat.public_ip
-}
-
 output "security_group_id" {
   value = aws_security_group.nat.id
 }

--- a/IaC/3-v3/aws/modules/nat-instance/user_data.sh.tpl
+++ b/IaC/3-v3/aws/modules/nat-instance/user_data.sh.tpl
@@ -1,13 +1,12 @@
 #!/bin/bash
 # ============================================================
 # V3 K8S IaC — NAT Instance user_data
-# ASG 교체 시 자동으로 EIP 연결 + RT route 갱신
+# ASG 교체 시 자동으로 source/dest check 비활성화 + RT route 갱신
 # Branch: feat/v3-k8s-iac
 # ============================================================
 set -euo pipefail
 
 REGION="${region}"
-EIP_ALLOC_ID="${eip_alloc_id}"
 ROUTE_TABLE_IDS="${route_table_ids}"
 VPC_CIDR="${vpc_cidr}"
 
@@ -16,13 +15,6 @@ TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
   -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
 INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
   http://169.254.169.254/latest/meta-data/instance-id)
-
-# --- Associate EIP ---
-aws ec2 associate-address \
-  --instance-id "$INSTANCE_ID" \
-  --allocation-id "$EIP_ALLOC_ID" \
-  --region "$REGION" \
-  --allow-reassociation
 
 # --- Disable source/dest check ---
 aws ec2 modify-instance-attribute \


### PR DESCRIPTION
## Summary
- EIP 한도 초과(`AddressLimitExceeded`)로 terraform apply 실패
- dev 환경이므로 EIP 대신 `associate_public_ip_address = true`로 동적 공인 IP 사용
- `aws_eip.nat` 리소스, user_data EIP 연결 로직, IAM `ec2:AssociateAddress` 권한 제거

## 주의
- 기존 apply에서 일부 리소스가 생성된 상태. 머지 후 destroy → apply 순서 필요할 수 있음