### PR TITLE
fix: 동적 인벤토리 SSM 연결 설정 수정

### DIFF
--- a/IaC/3-v3/ansible/inventory/aws_ec2.yaml
+++ b/IaC/3-v3/ansible/inventory/aws_ec2.yaml
@@ -26,8 +26,11 @@ hostnames:
   - private-ip-address
 
 compose:
-  ansible_host: private_ip_address
+  ansible_host: instance_id
+  ansible_connection: "'aws_ssm'"
+  ansible_aws_ssm_region: "'ap-northeast-2'"
   ansible_user: ubuntu
   k8s_role: tags['k8s:role']
   k8s_nodepool: tags['k8s:nodepool']
   node_az: placement.availability_zone
+  private_ip: private_ip_address


### PR DESCRIPTION
ansible_host를 private_ip → instance_id로 변경 (SSM 접속용). compose에 ansible_connection: aws_ssm 명시하여 SSH 대신 SSM 사용.