### PR TITLE
fix: SSM 연결 NoneType 에러 수정

### DIFF
--- a/.github/workflows/ansible-v3-k8s.yml
+++ b/.github/workflows/ansible-v3-k8s.yml
@@ -129,6 +129,5 @@ jobs:
           ansible-playbook \
             -i inventory/aws_ec2.yaml \
             playbooks/site.yml \
-            -e "ansible_aws_ssm_profile=" \
             -v
         working-directory: ${{ env.ANSIBLE_DIR }}

--- a/IaC/3-v3/ansible/group_vars/all.yml
+++ b/IaC/3-v3/ansible/group_vars/all.yml
@@ -23,6 +23,5 @@ containerd_version: "1.7"
 cluster_name: "dojangkok-v3"
 
 # SSM을 통한 접근 (SSH 대신)
-ansible_connection: aws_ssm
-ansible_aws_ssm_region: ap-northeast-2
-ansible_aws_ssm_profile: tf
+# 로컬: ansible-playbook -e ansible_aws_ssm_profile=tf ...
+# CI: OIDC 환경변수 사용 (profile 불필요)

--- a/IaC/3-v3/ansible/inventory/aws_ec2.yaml
+++ b/IaC/3-v3/ansible/inventory/aws_ec2.yaml
@@ -23,7 +23,7 @@ keyed_groups:
     separator: "_"
 
 hostnames:
-  - private-ip-address
+  - instance-id
 
 compose:
   ansible_host: instance_id


### PR DESCRIPTION
## Summary
- `ansible_aws_ssm_profile` 빈 문자열 전달 시 NoneType 에러 수정
- group_vars에서 profile 제거, CI는 OIDC 환경변수로 인증
- `hostnames`를 `instance-id`로 변경 (SSM 플러그인 직접 인식)
- 로컬 실행: `ansible-playbook -e ansible_aws_ssm_profile=tf playbooks/site.yml`