### PR TITLE
fix: NAT user_data에 AWS CLI 설치 추가

### DIFF
--- a/IaC/3-v3/aws/modules/nat-instance/user_data.sh.tpl
+++ b/IaC/3-v3/aws/modules/nat-instance/user_data.sh.tpl
@@ -6,6 +6,10 @@
 # ============================================================
 set -euo pipefail
 
+# --- Install AWS CLI ---
+DEBIAN_FRONTEND=noninteractive apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq awscli
+
 REGION="${region}"
 ROUTE_TABLE_IDS="${route_table_ids}"
 VPC_CIDR="${vpc_cidr}"


### PR DESCRIPTION
Ubuntu 24.04에 AWS CLI 미포함. route table 갱신, source/dest check 비활성화에 필요.