### PR TITLE
fix: NAT AWS CLI v2 바이너리 설치로 변경

### DIFF
--- a/IaC/3-v3/aws/modules/nat-instance/user_data.sh.tpl
+++ b/IaC/3-v3/aws/modules/nat-instance/user_data.sh.tpl
@@ -6,9 +6,13 @@
 # ============================================================
 set -euo pipefail
 
-# --- Install AWS CLI ---
+# --- Install AWS CLI v2 (ARM64) ---
 DEBIAN_FRONTEND=noninteractive apt-get update -qq
-DEBIAN_FRONTEND=noninteractive apt-get install -y -qq awscli
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq unzip
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /tmp
+/tmp/aws/install
+rm -rf /tmp/awscliv2.zip /tmp/aws
 
 REGION="${region}"
 ROUTE_TABLE_IDS="${route_table_ids}"


### PR DESCRIPTION
## Summary
- Ubuntu 24.04 ARM64에 `awscli` apt 패키지 없음 (`no installation candidate`)
- AWS 공식 CLI v2 aarch64 바이너리로 직접 설치
- 이전: `apt-get install awscli` → 실패
- 이후: `awscli-exe-linux-aarch64.zip` 다운로드 → 설치