### PR TITLE
fix: SSM become_user 권한 에러 수정 — --kubeconfig 플래그로 대체

### DIFF
--- a/IaC/3-v3/ansible/roles/calico/tasks/main.yml
+++ b/IaC/3-v3/ansible/roles/calico/tasks/main.yml
@@ -4,16 +4,14 @@
 # ============================================================
 
 - name: Install Tigera Operator
-  become_user: ubuntu
   command: >
-    kubectl create -f
+    kubectl --kubeconfig=/home/ubuntu/.kube/config create -f
     https://raw.githubusercontent.com/projectcalico/calico/v3.28.0/manifests/tigera-operator.yaml
   register: tigera_result
   failed_when: tigera_result.rc != 0 and 'already exists' not in tigera_result.stderr
   changed_when: "'created' in tigera_result.stdout"
 
 - name: Apply Calico custom resource
-  become_user: ubuntu
   copy:
     content: |
       apiVersion: operator.tigera.io/v1
@@ -30,13 +28,14 @@
     dest: /tmp/calico-installation.yaml
 
 - name: Apply Calico installation
-  become_user: ubuntu
-  command: kubectl apply -f /tmp/calico-installation.yaml
+  command: >
+    kubectl --kubeconfig=/home/ubuntu/.kube/config
+    apply -f /tmp/calico-installation.yaml
 
 - name: Wait for Calico pods to be ready
-  become_user: ubuntu
   command: >
-    kubectl wait --for=condition=Ready pods
+    kubectl --kubeconfig=/home/ubuntu/.kube/config
+    wait --for=condition=Ready pods
     --all -n calico-system
     --timeout=300s
   retries: 3

--- a/IaC/3-v3/ansible/roles/ebs-csi/tasks/main.yml
+++ b/IaC/3-v3/ansible/roles/ebs-csi/tasks/main.yml
@@ -4,15 +4,13 @@
 # ============================================================
 
 - name: Deploy EBS CSI Driver
-  become_user: ubuntu
   command: >
-    kubectl apply -k
+    kubectl --kubeconfig=/home/ubuntu/.kube/config apply -k
     "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.37"
   register: ebs_csi_result
   changed_when: "'created' in ebs_csi_result.stdout or 'configured' in ebs_csi_result.stdout"
 
 - name: Create gp3 StorageClass
-  become_user: ubuntu
   copy:
     content: |
       apiVersion: storage.k8s.io/v1
@@ -29,5 +27,6 @@
     dest: /tmp/storageclass-gp3.yaml
 
 - name: Apply StorageClass
-  become_user: ubuntu
-  command: kubectl apply -f /tmp/storageclass-gp3.yaml
+  command: >
+    kubectl --kubeconfig=/home/ubuntu/.kube/config
+    apply -f /tmp/storageclass-gp3.yaml

--- a/IaC/3-v3/ansible/roles/gateway-fabric/tasks/main.yml
+++ b/IaC/3-v3/ansible/roles/gateway-fabric/tasks/main.yml
@@ -4,28 +4,28 @@
 # ============================================================
 
 - name: Install Gateway API CRDs
-  become_user: ubuntu
   command: >
-    kubectl apply -f
+    kubectl --kubeconfig=/home/ubuntu/.kube/config apply -f
     https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
   register: gateway_api_result
   changed_when: "'created' in gateway_api_result.stdout"
 
 - name: Add NGINX Gateway Fabric Helm repo
-  become_user: ubuntu
-  command: helm repo add nginx-gateway https://kubernetes-sigs.github.io/nginx-gateway-fabric
+  command: >
+    helm --kubeconfig=/home/ubuntu/.kube/config
+    repo add nginx-gateway https://kubernetes-sigs.github.io/nginx-gateway-fabric
   register: helm_repo
   failed_when: helm_repo.rc != 0 and 'already exists' not in helm_repo.stderr
   changed_when: "'added' in helm_repo.stdout"
 
 - name: Update Helm repos
-  become_user: ubuntu
-  command: helm repo update
+  command: >
+    helm --kubeconfig=/home/ubuntu/.kube/config repo update
 
 - name: Install NGINX Gateway Fabric
-  become_user: ubuntu
   command: >
-    helm upgrade --install nginx-gateway nginx-gateway/nginx-gateway-fabric
+    helm --kubeconfig=/home/ubuntu/.kube/config
+    upgrade --install nginx-gateway nginx-gateway/nginx-gateway-fabric
     --namespace nginx-gateway --create-namespace
     --set service.type=NodePort
     --set service.ports[0].port=80,service.ports[0].nodePort={{ gateway_nodeport_http }}

--- a/IaC/3-v3/ansible/roles/kubeadm-init/tasks/main.yml
+++ b/IaC/3-v3/ansible/roles/kubeadm-init/tasks/main.yml
@@ -52,8 +52,8 @@
 
 - name: Label CP node
   command: >
-    kubectl label node {{ inventory_hostname }}
+    kubectl --kubeconfig=/home/ubuntu/.kube/config
+    label node {{ inventory_hostname }}
     node-role.kubernetes.io/control-plane=
     --overwrite
-  become_user: ubuntu
   changed_when: false

--- a/IaC/3-v3/ansible/roles/kubeadm-join/tasks/main.yml
+++ b/IaC/3-v3/ansible/roles/kubeadm-join/tasks/main.yml
@@ -14,9 +14,9 @@
 
 - name: Label worker node (from CP)
   delegate_to: "{{ groups['role_control_plane'][0] }}"
-  become_user: ubuntu
   command: >
-    kubectl label node {{ inventory_hostname }}
+    kubectl --kubeconfig=/home/ubuntu/.kube/config
+    label node {{ inventory_hostname }}
     node-role.kubernetes.io/worker=
     dojangkok.cloud/nodepool={{ k8s_nodepool | default('default') }}
     topology.kubernetes.io/zone={{ node_az }}


### PR DESCRIPTION
SSM 연결에서 become_user: ubuntu 사용 시 임시 파일 권한 설정 실패.
모든 kubectl/helm 명령에 --kubeconfig=/home/ubuntu/.kube/config 플래그 추가.