### PR TITLE
fix: Ansible SSM 배포 안정성 수정

### DIFF
--- a/IaC/3-v3/ansible/inventory/aws_ec2.yaml
+++ b/IaC/3-v3/ansible/inventory/aws_ec2.yaml
@@ -30,6 +30,7 @@ compose:
   ansible_connection: "'aws_ssm'"
   ansible_aws_ssm_region: "'ap-northeast-2'"
   ansible_aws_ssm_bucket_name: "'dojangkok-v3-ansible-ssm'"
+  ansible_aws_ssm_timeout: 360
   ansible_user: ubuntu
   k8s_role: tags['k8s:role']
   k8s_nodepool: tags['k8s:nodepool']

--- a/IaC/3-v3/ansible/roles/calico/tasks/main.yml
+++ b/IaC/3-v3/ansible/roles/calico/tasks/main.yml
@@ -37,8 +37,8 @@
     kubectl --kubeconfig=/home/ubuntu/.kube/config
     wait --for=condition=Ready pods
     --all -n calico-system
-    --timeout=50s
-  retries: 10
-  delay: 15
+    --timeout=300s
+  retries: 3
+  delay: 10
   register: calico_ready
   until: calico_ready.rc == 0


### PR DESCRIPTION
## Summary
- `become_user: ubuntu` → `--kubeconfig` 플래그로 대체 (SSM 권한 에러 해결)
- SSM 세션 타임아웃 60초 → 360초 증가 (장시간 명령 지원)
- NAT instance AWS CLI v2 설치 추가 (Ubuntu 24.04 ARM64)
- group_vars 경로 수정, SSM 연결 설정 보완

## Test plan
- [ ] Ansible deploy (workflow_dispatch) 실행
- [ ] Calico pods Ready 대기 정상 통과 확인
- [ ] 전체 K8S 클러스터 부트스트랩 완료 확인