### PR TITLE
fix: SSM 타임아웃 + Ansible 배포 안정성 수정

### DIFF
--- a/IaC/3-v3/ansible/ansible.cfg
+++ b/IaC/3-v3/ansible/ansible.cfg
@@ -2,5 +2,5 @@
 roles_path = ./roles
 inventory = ./inventory/aws_ec2.yaml
 host_key_checking = False
-timeout = 60
+timeout = 360
 deprecation_warnings = False

--- a/IaC/3-v3/ansible/roles/calico/tasks/main.yml
+++ b/IaC/3-v3/ansible/roles/calico/tasks/main.yml
@@ -37,8 +37,8 @@
     kubectl --kubeconfig=/home/ubuntu/.kube/config
     wait --for=condition=Ready pods
     --all -n calico-system
-    --timeout=300s
-  retries: 3
-  delay: 10
+    --timeout=50s
+  retries: 10
+  delay: 15
   register: calico_ready
   until: calico_ready.rc == 0


### PR DESCRIPTION
## Summary
- `ansible.cfg` timeout 60초 → 360초 (SSM 세션 타임아웃 해제)
- `ansible_aws_ssm_timeout: 360` 인벤토리에 추가 (이중 방어)
- Calico wait를 50s × 10회 분할 재시도로 변경
- `become_user: ubuntu` → `--kubeconfig` 플래그로 전면 대체

## Test plan
- [ ] Ansible deploy 시 Calico wait 타임아웃 없이 통과
- [ ] 전체 K8S 클러스터 부트스트랩 완료 확인