### PR TITLE
fix: Calico Typha 5473/tcp SG 규칙 추가

### DIFF
--- a/IaC/3-v3/aws/environments/k8s-dev/main.tf
+++ b/IaC/3-v3/aws/environments/k8s-dev/main.tf
@@ -103,6 +103,7 @@ module "security_groups" {
         { from_port = 10257, to_port = 10257, protocol = "tcp", cidr_blocks = [var.vpc_cidr], description = "kube-controller-manager" },
         { from_port = 10259, to_port = 10259, protocol = "tcp", cidr_blocks = [var.vpc_cidr], description = "kube-scheduler" },
         { from_port = 4789, to_port = 4789, protocol = "udp", cidr_blocks = [var.vpc_cidr], description = "Calico VXLAN" },
+        { from_port = 5473, to_port = 5473, protocol = "tcp", cidr_blocks = [var.vpc_cidr], description = "Calico Typha" },
       ]
     }
 
@@ -111,6 +112,7 @@ module "security_groups" {
       ingress_rules = [
         { from_port = 10250, to_port = 10250, protocol = "tcp", cidr_blocks = [var.vpc_cidr], description = "kubelet" },
         { from_port = 4789, to_port = 4789, protocol = "udp", cidr_blocks = [var.vpc_cidr], description = "Calico VXLAN" },
+        { from_port = 5473, to_port = 5473, protocol = "tcp", cidr_blocks = [var.vpc_cidr], description = "Calico Typha" },
         { from_port = 30000, to_port = 32767, protocol = "tcp", cidr_blocks = [var.vpc_cidr], description = "NodePort range" },
       ]
     }


### PR DESCRIPTION
## Summary
- CP/Worker SG에 Calico Typha 포트(5473/tcp) 추가
- calico-node → Typha 통신 차단으로 전체 calico-node Not Ready 상태였음
- SSM 타임아웃 360초 증가, become_user → --kubeconfig 전환 포함

## Test plan
- [ ] Terraform apply로 SG 규칙 추가 확인
- [ ] Calico pods 전체 Ready 상태 전환 확인
- [ ] Ansible deploy로 나머지 컴포넌트(ebs-csi, gateway-fabric) 설치 확인